### PR TITLE
Create pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # burendo-githooks
 Default Git hooks for Burendo repositories
+
+
+### pre-commit
+
+A pre-commit is designed to catch any secret/private content being accidently commited to public repositories. These include AWS Account IDs, Access key IDs, IP addresses, email addresses etc... This can been adjusted to ignore lines beginning Subproject commit to avoid triggering its own pre-commit check ("40 character random (e.g. AWS secret access key, PAT)").

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,86 @@
+#!/bin/bash
+#set -x
+declare -a patterns=(
+    "\b[A-Z0-9]{20}\b"
+    "\b[A-Za-z0-9\/+=]{40}\b"
+    "\b[0-9]{12}\b"
+    "\b[a-z0-9]{32}\b"
+    "PRIVATE KEY-----"
+    "\b.[a-z]{2}-[a-z]{4,9}-[0-9]{1}.\b"
+)
+
+declare -a descriptions=(
+    "AWS access key ID"
+    "40 character random (e.g. AWS secret access key, PAT)"
+    "AWS account number"
+    "16 byte hex (e.g. S3 bucket name)"
+    "Private key (e.g. rsa private key, openssh private key)"
+    "Regions embedded as part of resource descriptions"
+)
+
+declare -a email_patterns=(
+    "\b[A-Za-z0-9._%+-]{1,}@[A-Za-z0-9]{1,}.[A-Za-z0-9]{1,4}.[A-Za-z0-9]{1,4}\b"
+)
+
+declare -a email_descriptions=(
+    "Email addresses"
+)
+
+declare -a ip_patterns=(
+    "\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+)
+
+declare -a ip_descriptions=(
+    "IP address"
+)
+
+declare -a allowed_tags=(
+    "@given"
+    "@when"
+    "@then"
+)
+
+if [ -d ".gitsecret" ]; then
+    git secret hide
+fi
+
+
+match=0
+for i in "${!patterns[@]}"
+do
+    git diff-index -p -M --cached HEAD -- | grep -v "Subproject commit" | grep -v "mxfile host" |
+    grep '^+[^+]' | grep -Eq "${patterns[$i]}" &&
+    echo "Blocking commit: ${descriptions[$i]} detected in patch" &&
+    echo "This part of your change triggered this issue:" &&
+    git diff-index -p -M --cached HEAD -- | grep -v "Subproject commit" | grep -v "mxfile host" |
+    grep '^+[^+]' | grep -E "${patterns[$i]}" &&
+    ((match++))
+done
+
+for i in "${!email_patterns[@]}"
+do
+    git diff-index -p -M --cached HEAD -- | grep -v "snyk/snyk@"| grep -v "create-release@latest"| grep -v "checkout@master"| grep -v "Publish-Docker-Github-Action@master"| grep -v "docker@master"|
+    grep -Eq -v "${allowed_tags[$i]}" | grep '^+[^+]' | grep -Eq "${email_patterns[$i]}" &&
+    echo "Blocking commit: ${email_descriptions[$i]} detected in patch" &&
+    echo "This part of your change triggered this issue:" &&
+    git diff-index -p -M --cached HEAD -- | grep -v "snyk/snyk@"| grep -v "create-release@latest"| grep -v "checkout@master"| grep -v "Publish-Docker-Github-Action@master"| grep -v "docker@master"|
+    grep -Eq -v "${allowed_tags[$i]}" | grep '^+[^+]' | grep -E "${email_patterns[$i]}" &&
+    ((match++))
+done
+
+for i in "${!ip_patterns[@]}"
+do
+    git diff-index -p -M --cached HEAD -- | grep -v "169.254.169.254" | grep -v "0.0.0.0" | grep -v "127.0.0.1" |
+    grep '^+[^+]' | grep -Eq "${ip_patterns[$i]}" &&
+    echo "Blocking commit: ${ip_descriptions[$i]} detected in patch" &&
+    echo "This part of your change triggered this issue:" &&
+    git diff-index -p -M --cached HEAD -- | grep -v "169.254.169.254" | grep -v "0.0.0.0" | grep -v "127.0.0.1" |
+    grep '^+[^+]' | grep -E "${ip_patterns[$i]}" &&
+    ((match++))
+done
+
+if (( match > 0 )); then
+    echo "If the above are false positives then you can use the --no-verify flag to skip checks"
+    echo "git commit --no-verify"
+    exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Chris Scott-Thomas <chris.scott-thomas@burendo.com>

## what
* Create pre-commit hook for use in repositories
* Update README

## why
* Standardising hooks to catch potential issues when committing to git.

## references
* See link to handbook - repository templates